### PR TITLE
Add API-backed login and registration handlers to Account page

### DIFF
--- a/ClientApp/app/pages/account/login.tsx
+++ b/ClientApp/app/pages/account/login.tsx
@@ -1,4 +1,66 @@
+import { type FormEvent, useState } from "react";
+
+type ApiStatus = "idle" | "loading" | "success" | "error";
+
 export function Login() {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [status, setStatus] = useState<ApiStatus>("idle");
+  const [message, setMessage] = useState("");
+
+  const handleApiCall = async (action: "login" | "register") => {
+    setStatus("loading");
+    setMessage("");
+
+    try {
+      const response = await fetch("https://aladdindev001/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password, action }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || "Request failed.");
+      }
+
+      const payload = await response.json().catch(() => null);
+      const successMessage =
+        action === "login"
+          ? "Welcome back! You are now signed in."
+          : "Account created! You can now sign in.";
+
+      setStatus("success");
+      setMessage(payload?.message ?? successMessage);
+    } catch (error) {
+      const description =
+        error instanceof Error ? error.message : "Something went wrong.";
+      setStatus("error");
+      setMessage(description);
+    }
+  };
+
+  const handleLoginSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!username || !password) {
+      setStatus("error");
+      setMessage("Please enter both a username and password.");
+      return;
+    }
+    await handleApiCall("login");
+  };
+
+  const handleCreateAccount = async () => {
+    if (!username || !password) {
+      setStatus("error");
+      setMessage("Please enter both a username and password.");
+      return;
+    }
+    await handleApiCall("register");
+  };
+
   return (
     <main className="container py-5">
       <div className="row justify-content-center">
@@ -9,7 +71,7 @@ export function Login() {
               <p className="text-muted">
                 Use your username and password to sign in or create a new account.
               </p>
-              <form>
+              <form onSubmit={handleLoginSubmit}>
                 <div className="mb-3">
                   <label className="form-label" htmlFor="username">
                     Username
@@ -22,6 +84,8 @@ export function Login() {
                     autoComplete="username"
                     placeholder="Enter your username"
                     required
+                    value={username}
+                    onChange={(event) => setUsername(event.target.value)}
                   />
                 </div>
                 <div className="mb-3">
@@ -36,17 +100,38 @@ export function Login() {
                     autoComplete="current-password"
                     placeholder="Enter your password"
                     required
+                    value={password}
+                    onChange={(event) => setPassword(event.target.value)}
                   />
                 </div>
                 <div className="d-flex flex-column flex-sm-row gap-2">
-                  <button className="btn btn-primary" type="submit">
-                    Login
+                  <button
+                    className="btn btn-primary"
+                    type="submit"
+                    disabled={status === "loading"}
+                  >
+                    {status === "loading" ? "Logging in..." : "Login"}
                   </button>
-                  <button className="btn btn-outline-secondary" type="button">
-                    Create New Account
+                  <button
+                    className="btn btn-outline-secondary"
+                    type="button"
+                    onClick={handleCreateAccount}
+                    disabled={status === "loading"}
+                  >
+                    {status === "loading" ? "Creating..." : "Create New Account"}
                   </button>
                 </div>
               </form>
+              {message ? (
+                <div
+                  className={`mt-3 alert ${
+                    status === "error" ? "alert-danger" : "alert-success"
+                  }`}
+                  role="alert"
+                >
+                  {message}
+                </div>
+              ) : null}
               <div className="mt-4 border-top pt-3">
                 <h2 className="h5">New to Artisan Cafe?</h2>
                 <p className="mb-0 text-muted">


### PR DESCRIPTION
### Motivation
- Enable the Account page to perform real login and registration requests to the backend at `https://aladdindev001/users` and surface server feedback to the user.  
- Improve UX by wiring the form inputs to component state, showing loading status, and preventing duplicate actions while requests are in-flight.

### Description
- Convert the `Login` component to use `useState` for `username`, `password`, `status`, and `message`.  
- Add `handleApiCall(action)` which sends a `POST` with JSON `{ username, password, action }` to `https://aladdindev001/users`, checks `response.ok`, parses optional JSON payload, and sets success or error messages.  
- Wire the form `onSubmit` to `handleLoginSubmit` and add `handleCreateAccount` to trigger the `register` action, with both paths validating inputs and updating loading/error/success state.  
- Disable buttons while `status === "loading"` and render an inline alert showing either the server `message` or a local success/error text.

### Testing
- Ran `npm install` in `ClientApp`, but it failed with a `403 Forbidden` when fetching `https://registry.npmjs.org/react-dom`, so the dev build and runtime checks could not be performed.  
- No unit or integration tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f2ce4d480832e80dc4f7c76035037)